### PR TITLE
Hack the outputs of prep so the call caching is disabled at the task …

### DIFF
--- a/pipelines/cellranger/adapter.wdl
+++ b/pipelines/cellranger/adapter.wdl
@@ -30,6 +30,9 @@ task GetInputs {
                   "${dss_url}")
 
     CODE
+
+    # hacky way to disable call-caching on the task level
+    date +%s > timestamp.txt
   >>>
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:" + pipeline_tools_version

--- a/pipelines/cellranger/adapter.wdl
+++ b/pipelines/cellranger/adapter.wdl
@@ -39,6 +39,7 @@ task GetInputs {
     String reference_name = read_string("reference_name.txt")
     File transcriptome_tar_gz = read_string("transcriptome_tar_gz.txt")
     Int expect_cells = read_string("expect_cells.txt")
+    String timestamp = read_string("timestamp.txt") # this is a hack to force disabling the task level call-caching
     Array[File] fastqs = read_lines("fastqs.txt")
     Array[String] fastq_names = read_lines("fastq_names.txt")
     Array[File] http_requests = glob("request_*.txt")

--- a/pipelines/optimus/adapter.wdl
+++ b/pipelines/optimus/adapter.wdl
@@ -42,6 +42,7 @@ task GetInputs {
     Array[String] r1_fastq = read_lines("r1.txt")
     Array[String] r2_fastq = read_lines("r2.txt")
     File i1_file = "i1.txt"
+    String timestamp = read_string("timestamp.txt") # this is a hack to force disabling the task level call-caching
     Array[String] i1_fastq = if(ceil(size(i1_file)) == 0) then [] else read_lines(i1_file)
     Array[File] http_requests = glob("request_*.txt")
     Array[File] http_responses = glob("response_*.txt")

--- a/pipelines/optimus/adapter.wdl
+++ b/pipelines/optimus/adapter.wdl
@@ -30,6 +30,9 @@ task GetInputs {
                 "${dss_url}")
 
     CODE
+
+    # hacky way to disable call-caching on the task level
+    date +%s > timestamp.txt
   >>>
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:" + pipeline_tools_version

--- a/pipelines/ss2_single_end/adapter.wdl
+++ b/pipelines/ss2_single_end/adapter.wdl
@@ -30,6 +30,9 @@ task GetInputs {
                   "${dss_url}")
 
     CODE
+
+    # hacky way to disable call-caching on the task level
+    date +%s > timestamp.txt
   >>>
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:" + pipeline_tools_version
@@ -38,6 +41,7 @@ task GetInputs {
     Array[File] http_requests = glob("request_*.txt")
     Array[File] http_responses = glob("response_*.txt")
     Object inputs = read_object("inputs.tsv")
+    String timestamp = read_string("timestamp.txt") # this is a hack to force disabling the task level call-caching
   }
 }
 

--- a/pipelines/ss2_single_sample/adapter.wdl
+++ b/pipelines/ss2_single_sample/adapter.wdl
@@ -30,6 +30,9 @@ task GetInputs {
                   "${dss_url}")
 
     CODE
+
+    # hacky way to disable call-caching on the task level
+    date +%s > timestamp.txt
   >>>
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:" + pipeline_tools_version
@@ -38,6 +41,7 @@ task GetInputs {
     Array[File] http_requests = glob("request_*.txt")
     Array[File] http_responses = glob("response_*.txt")
     Object inputs = read_object("inputs.tsv")
+    String timestamp = read_string("timestamp.txt") # this is a hack to force disabling the task level call-caching
   }
 }
 


### PR DESCRIPTION
…level.

### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

- https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-533

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Hack the outputs of prep so the call caching is disabled at the task level.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

~Needs to be reviewed along with another PR: https://github.com/HumanCellAtlas/pipeline-tools/pull/169~

- A workflow started by the integration test suite succeeded: https://job-manager.caas-prod.broadinstitute.org/jobs/e9053ef2-818d-4ce3-bb37-c9fcd791f37f
