### PR TITLE
Pass pipeline version into adapter wdl

### DIFF
--- a/pipelines/cellranger/adapter.wdl
+++ b/pipelines/cellranger/adapter.wdl
@@ -142,6 +142,7 @@ workflow Adapter10xCount {
   Int? retry_timeout
   Int? individual_request_timeout
   String reference_bundle
+  String pipeline_version
 
   # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
@@ -253,7 +254,7 @@ workflow Adapter10xCount {
       record_http = record_http,
       pipeline_tools_version = pipeline_tools_version,
       add_md5s = add_md5s,
-      pipeline_version = analysis.pipeline_version,
+      pipeline_version = pipeline_version,
       # The sorted bam is the largest output. Other outputs will increase space by ~50%.
       # Factor of 2 and addition of 50 GB gives some buffer.
       disk_space = ceil(size(analysis.sorted_bam, "GB") * 2 + 50)

--- a/pipelines/optimus/adapter.wdl
+++ b/pipelines/optimus/adapter.wdl
@@ -132,6 +132,7 @@ workflow AdapterOptimus {
   Int? retry_timeout
   Int? individual_request_timeout
   String reference_bundle
+  String pipeline_version
 
   # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
@@ -234,7 +235,7 @@ workflow AdapterOptimus {
       record_http = record_http,
       pipeline_tools_version = pipeline_tools_version,
       add_md5s = add_md5s,
-      pipeline_version = analysis.pipeline_version,
+      pipeline_version = pipeline_version,
       # The disk space value here is still an experiment value, need to 
       # be optimized based on historical data by CBs
       disk_space = ceil(size(analysis.bam, "GB") * 2 + 50)

--- a/pipelines/ss2_single_end/adapter.wdl
+++ b/pipelines/ss2_single_end/adapter.wdl
@@ -63,6 +63,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int? retry_timeout
   Int? individual_request_timeout
   String reference_bundle
+  String pipeline_version
 
   # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
@@ -187,7 +188,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
       record_http = record_http,
       pipeline_tools_version = pipeline_tools_version,
       add_md5s = add_md5s,
-      pipeline_version = analysis.pipeline_version,
+      pipeline_version = pipeline_version,
       # The bam files are by far the largest outputs. The extra 5 GB should easily cover everything else.
       disk_space = ceil(size(analysis.aligned_bam, "GB") + size(analysis.aligned_transcriptome_bam, "GB") + 5)
   }

--- a/pipelines/ss2_single_sample/adapter.wdl
+++ b/pipelines/ss2_single_sample/adapter.wdl
@@ -63,6 +63,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int? retry_timeout
   Int? individual_request_timeout
   String reference_bundle
+  String pipeline_version
 
   # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
@@ -193,7 +194,7 @@ workflow AdapterSmartSeq2SingleCell{
       record_http = record_http,
       pipeline_tools_version = pipeline_tools_version,
       add_md5s = add_md5s,
-      pipeline_version = analysis.pipeline_version,
+      pipeline_version = pipeline_version,
       # The bam files are by far the largest outputs. The extra 5 GB should easily cover everything else.
       disk_space = ceil(size(analysis.aligned_bam, "GB") + size(analysis.aligned_transcriptome_bam, "GB") + 5)
   }


### PR DESCRIPTION
### Purpose
Getting the pipeline version from the outputs of the analysis workflow requires keeping that hard-coded version variable up to date in the analysis pipeline. This is prone to manual errors and complicates the release process for pipelines in Skylab.

### Changes
Lira will pass the pipeline version into the adapter WDL with this [PR](https://github.com/HumanCellAtlas/lira/pull/188)
Pass this value into the submit subworkflow instead of consuming the variable from the analysis pipeline outputs.

### Review Instructions
- No instructions.
